### PR TITLE
Fix default driver retrieval for quote manager

### DIFF
--- a/app/Services/NewQuoteManager.php
+++ b/app/Services/NewQuoteManager.php
@@ -21,6 +21,6 @@ class NewQuoteManager extends Manager
 
     public function getDefaultDriver()
     {
-        return $this->config->get('session.driver');
+        return $this->config->get('kanye.driver', 'kanyeRest');
     }
 }

--- a/config/kanye.php
+++ b/config/kanye.php
@@ -1,4 +1,4 @@
 <?php
 return [
-    'driver' =>env('KANYE_DRIVER', 'KanyeRest'),
+    'driver' => env('KANYE_DRIVER', 'kanyeRest'),
 ];

--- a/tests/Unit/NewQuoteManagerTest.php
+++ b/tests/Unit/NewQuoteManagerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\NewQuoteManager;
+use Tests\TestCase;
+
+class NewQuoteManagerTest extends TestCase
+{
+    public function test_it_uses_kanye_config_as_default_driver(): void
+    {
+        config(['kanye.driver' => 'jsonFile']);
+
+        $manager = app(NewQuoteManager::class);
+
+        $this->assertSame('jsonFile', $manager->getDefaultDriver());
+    }
+}


### PR DESCRIPTION
## Summary
- Pull default quote driver from the dedicated `kanye` config instead of the session driver
- Set default driver value to `kanyeRest`
- Add unit test verifying manager uses the `kanye` configuration

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= DB_DATABASE=/tmp/kanye_quotes_test.sqlite ./vendor/bin/phpunit --filter NewQuoteManagerTest`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= DB_DATABASE=/tmp/kanye_quotes_test.sqlite ./vendor/bin/phpunit` *(fails: table api_access has no column named name)*

------
https://chatgpt.com/codex/tasks/task_e_6898752221ac832c971a32f260350c2a